### PR TITLE
Fix bash completion path in README

### DIFF
--- a/labdemo/README.md
+++ b/labdemo/README.md
@@ -26,7 +26,14 @@
    alias kc='kubectx'
    alias kn='kubens'
 
-   source /etc/bash_completion
+  # load bash completion scripts
+  # the bash-completion package installs them under /usr/share/bash-completion
+  # some older systems symlink /etc/bash_completion to this file
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    source /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    source /etc/bash_completion
+  fi
    source <(kubectl completion bash)
    complete -o default -F __start_kubectl k
    ```


### PR DESCRIPTION
## Summary
- improve bash completion detection in README instructions

## Testing
- `git ls-remote https://github.com/ahmetb/kubectx 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_6854103a87bc832dbb4e7306b1fdaaad